### PR TITLE
Fixing Style. TextEditor and  ContentPresenter are overlapping.

### DIFF
--- a/ShowMeTheXAML.AvalonEdit/Themes/XamlDisplayer.xaml
+++ b/ShowMeTheXAML.AvalonEdit/Themes/XamlDisplayer.xaml
@@ -31,12 +31,14 @@
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
-                            <avalonedit:TextEditor Document="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TextDocumentValueConverter}}" 
+                            <avalonedit:TextEditor Grid.Column="1"
+                                                   Document="{Binding Xaml, RelativeSource={RelativeSource TemplatedParent}, Converter={StaticResource TextDocumentValueConverter}}" 
                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                    Style="{StaticResource AvalonTextEditorXamlDisplay}"
                                                    DockPanel.Dock="{Binding Path=(DockPanel.Dock), RelativeSource={RelativeSource TemplatedParent}}"/>
-                            <ContentPresenter VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
+                            <ContentPresenter Grid.Column="0"
+                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}" 
                                               HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" />
 
                         </Grid>


### PR DESCRIPTION
Fixing this problem.

![2018-02-10 00 59 18](https://user-images.githubusercontent.com/23096880/36036626-ad63d218-0dfd-11e8-8b1c-bb1cdd841c06.png)

```xaml
<smtx:XamlDisplay Key="Unique7" Style="{StaticResource AvalonEditXamlDisplay}">
    <StackPanel>
        <Button Content="Some Content" />
        <TextBlock Text="Some Text" />
    </StackPanel>
</smtx:XamlDisplay>
```