### PR TITLE
Adds README to NuGet packages and cleans projects

### DIFF
--- a/ShowMeTheXAML.AvalonEdit/ShowMeTheXAML.AvalonEdit.csproj
+++ b/ShowMeTheXAML.AvalonEdit/ShowMeTheXAML.AvalonEdit.csproj
@@ -17,6 +17,7 @@
         <Copyright>Copyright 2025</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <RepositoryUrl>https://github.com/Keboo/ShowMeTheXAML</RepositoryUrl>
@@ -25,19 +26,9 @@
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
     </PropertyGroup>
     
-    <ItemGroup Condition="$(TargetFramework) == 'net472'">
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Xaml" />
-        <Reference Include="WindowsBase" />
-        <Reference Include="PresentationCore" />
-        <Reference Include="PresentationFramework" />
-    </ItemGroup>
     <ItemGroup>
-        <None Include="Properties\Settings.settings">
-            <Generator>SettingsSingleFileGenerator</Generator>
-            <LastGenOutput>Settings.Designer.cs</LastGenOutput>
-        </None>
         <None Include="..\icon.png" Pack="true" PackagePath="\" />
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="AvalonEdit" />

--- a/ShowMeTheXAML.MSBuild/ShowMeTheXAML.MSBuild.csproj
+++ b/ShowMeTheXAML.MSBuild/ShowMeTheXAML.MSBuild.csproj
@@ -16,6 +16,7 @@
         <Copyright>Copyright 2025</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <RepositoryUrl>https://github.com/Keboo/ShowMeTheXAML</RepositoryUrl>
@@ -40,6 +41,7 @@
 
     <ItemGroup>
         <None Include="..\icon.png" Pack="true" PackagePath="\" />
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 
@@ -58,7 +60,7 @@
             <TaskOutputDirectory Condition="$(TargetFramework) == 'netstandard2.0'">netcore</TaskOutputDirectory>
         </PropertyGroup>
 
-        <WriteLinestoFile File="$(EmptyFile)" />
+        <WriteLinesToFile File="$(EmptyFile)" />
         <ItemGroup>
             <TfmSpecificPackageFile Include="$(ProjectDir)bin\$(Configuration)\$(TargetFramework)\*" Condition="$(TargetFramework) == 'net472' Or $(TargetFramework) == 'netstandard2.0'">
                 <PackagePath>tools\$(TaskOutputDirectory)</PackagePath>

--- a/ShowMeTheXAML/ShowMeTheXAML.csproj
+++ b/ShowMeTheXAML/ShowMeTheXAML.csproj
@@ -16,6 +16,7 @@
         <Copyright>Copyright 2025</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageIcon>icon.png</PackageIcon>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
         <RepositoryUrl>https://github.com/Keboo/ShowMeTheXAML</RepositoryUrl>
@@ -30,5 +31,6 @@
 
     <ItemGroup>
         <None Include="..\icon.png" Pack="true" PackagePath="\" />
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds `PackageReadmeFile` and includes `README.md` for all NuGet packages, removes legacy .NET Framework 4.7.2 references and project settings from `ShowMeTheXAML.AvalonEdit`, and corrects `WriteLinestoFile` typo in `ShowMeTheXAML.MSBuild`.
